### PR TITLE
add JUnit tests for Product and Order classes

### DIFF
--- a/src/main/java/pl/edu/pjwstk/byt/Order.java
+++ b/src/main/java/pl/edu/pjwstk/byt/Order.java
@@ -13,7 +13,7 @@ public class Order implements Serializable {
     private List<Product> items; // Order consists of (1..*) Products
 
     public Order(LocalDateTime orderDate, String status) {
-        if (orderDate == null) throw new IllegalArgumentException("Order date cannot be null");
+        if (orderDate == null) throw new IllegalArgumentException("Order date canot be null");
         if (orderDate.isAfter(LocalDateTime.now())) throw new IllegalArgumentException("Order date cannot be in the future");
         if (status == null || status.isBlank()) throw new IllegalArgumentException("Status cannot be empty");
 
@@ -45,14 +45,16 @@ public class Order implements Serializable {
     }
 
     public void changeOrderStatus(String newStatus) {
-        if (newStatus == null || newStatus.isBlank())
+        if (newStatus == null || newStatus.isBlank()) {
             throw new IllegalArgumentException("Invalid status");
+        }
         status = newStatus;
     }
 
     public void checkPendingOrders() {
-        if (status.equalsIgnoreCase("pending"))
+        if (status.equalsIgnoreCase("pending")) {
             System.out.println("Order is still pending...");
+        }
     }
 
     @Override

--- a/src/main/java/pl/edu/pjwstk/byt/Product.java
+++ b/src/main/java/pl/edu/pjwstk/byt/Product.java
@@ -8,8 +8,8 @@ public class Product {
     private double price;
     private int stockQuantity;
     private List<String> images; // multi value attribute [1..*]
-    private List<Integer> rating; // list of ratings
-    private double avgRating; // /avgRating (derived)
+    private List<Integer> rating;
+    private double avgRating; // derived attribute
 
 
     private static List<Product> extent = new ArrayList<>();
@@ -31,8 +31,9 @@ public class Product {
     }
 
     public void updateStock(int change) {
-        if (stockQuantity + change < 0)
+        if (stockQuantity + change < 0) {
             throw new IllegalArgumentException("Not enough stock");
+        }
         stockQuantity += change;
     }
 
@@ -47,8 +48,9 @@ public class Product {
     }
 
     public void addReview(int stars) {
-        if (stars < 1 || stars > 5)
-            throw new IllegalArgumentException("Rating must be between 1 and 5");
+        if (stars < 1 || stars > 5) {
+            throw new IllegalArgumentException("Stars must be between 1 and 5");
+        }
         rating.add(stars);
         calculateAverageRating();
     }
@@ -64,8 +66,13 @@ public class Product {
 
     public static List<Product> getExtent() { return extent; }
 
+    public List<String> getImages() {
+        return new ArrayList<>(images);
+    }
+
+
     @Override
     public String toString() {
-        return name + " | Price: " + price + " | Avg Rating: " + avgRating;
+        return name + " Price: " + price + " Avg Rating: " + avgRating;
     }
 }

--- a/src/test/java/pl/edu/pjwstk/byt/OrderTest.java
+++ b/src/test/java/pl/edu/pjwstk/byt/OrderTest.java
@@ -1,0 +1,37 @@
+package pl.edu.pjwstk.byt;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OrderTest {
+
+    // Complex attribute (orderDate) TESTS
+    @Test
+    void shouldCreateOrderWithValidDate() {
+        var order = new Order(LocalDateTime.now().minusDays(1), "pending");
+        assertNotNull(order);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenOrderDateIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Order(null, "pending")
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenOrderDateIsInFuture() {
+        var futureDate = LocalDateTime.now().plusDays(1);
+        assertThrows(IllegalArgumentException.class, () ->
+                new Order(futureDate, "pending")
+        );
+    }
+
+    @Test
+    void shouldSetStatusCorrectlyOnCreation() {
+        var now = LocalDateTime.now();
+        var order = new Order(now, "completed");
+        assertEquals("completed", order.getStatus());
+    }
+}

--- a/src/test/java/pl/edu/pjwstk/byt/ProductTest.java
+++ b/src/test/java/pl/edu/pjwstk/byt/ProductTest.java
@@ -1,0 +1,73 @@
+package pl.edu.pjwstk.byt;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProductTest {
+
+    // Basic attribute (name) TESTS
+    @Test
+    void shouldCreateProductWithValidName() {
+        var product = new Product("Phone", "Smartphone", 1500.0, 5, List.of("img1.jpg"));
+        assertEquals("Phone", product.getName());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNameIsEmpty() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Product("", "Smartphone", 1500.0, 5, List.of("img1.jpg"))
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNameIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Product(null, "Smartphone", 1500.0, 5, List.of("img1.jpg"))
+        );
+    }
+
+    // Multi-value attribute (images) TESTS
+    @Test
+    void shouldAcceptMultipleImages() {
+        var images = List.of("front.jpg", "back.jpg");
+        var product = new Product("Camera", "DSLR", 2500.0, 10, images);
+        assertEquals(2, product.getImages().size());
+    }
+
+
+    @Test
+    void shouldThrowExceptionWhenImagesListIsEmpty() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Product("Camera", "DSLR", 2500.0, 10, List.of())
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenImagesListIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Product("Camera", "DSLR", 2500.0, 10, null)
+        );
+    }
+
+    // Derived attribute (avgRating) TESTS
+    @Test
+    void shouldCalculateAverageRatingCorrectly() {
+        var product = new Product("Laptop", "Gaming laptop", 4000.0, 5, List.of("img1.jpg"));
+        product.addReview(5);
+        product.addReview(3);
+        assertEquals(4.0, product.getAvgRating());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenRatingOutOfRange() {
+        var product = new Product("Laptop", "Gaming laptop", 4000.0, 5, List.of("img1.jpg"));
+        assertThrows(IllegalArgumentException.class, () -> product.addReview(6));
+    }
+
+    @Test
+    void shouldReturnZeroWhenNoRatingsGiven() {
+        var product = new Product("Mouse", "Wireless", 100.0, 10, List.of("img1.jpg"));
+        assertEquals(0.0, product.getAvgRating());
+    }
+}


### PR DESCRIPTION
This PR adds basic JUnit 5 tests for Product and Order classes.
- Covers validation of basic, multi-value, and derived attributes.
- Ensures correct handling of invalid inputs.